### PR TITLE
Mudancas NCP

### DIFF
--- a/servers/2-main/plugins/NoCheatPlus/config.yml
+++ b/servers/2-main/plugins/NoCheatPlus/config.yml
@@ -104,7 +104,7 @@ checks:
       active: false
       actions: cancel vl>10 log:noswing:0:5:i cancel
     reach:
-      active: false
+      active: true
       actions: cancel
     wrongblock:
       active: true
@@ -125,8 +125,8 @@ checks:
       actions: cancel log:breach:5:6:i
     speed:
       active: true
-      interval: 200
-      limit: 50
+      interval: 750
+      limit: 6
       actions: cancel
     visible:
       active: false
@@ -134,7 +134,7 @@ checks:
   blockplace:
     active: true
     against:
-      active: false
+      active: true
       actions: cancel log:against:1:5:i vl>10 cancel log:against:0:2:if cmdc:kickagainst:0:10
     autosign:
       active: default
@@ -144,7 +144,7 @@ checks:
       active: true
       actions: cancel
     fastplace:
-      active: false
+      active: true
       limit: 15
       shortterm:
         ticks: 10


### PR DESCRIPTION
tava conversando com o pessoal do pevepas e acheu melhor fazer algumas mudancas no ac com esse update, nada perceptivel quando vc for construir uma base ou no vanilla

1. liguei o reach do blockbreak pra evitar problemas
2. botei um limite no blockinteractspeed de 6 cristais em 750ms, o crystalaura tava muito rapido e n tava legal de jogar
3. liguei o against no blockplace, infelizmente isso patcha liquidinteract mas tbm patcha airplace
4. liguei o fastplace do blockplace mas nada dms tb (tanto ate q da pra usar insta surround)