### PR TITLE
Patch de Crystal Spam exploit

### DIFF
--- a/servers/2-main/plugins/AnarchyExploitFixes/config.yml
+++ b/servers/2-main/plugins/AnarchyExploitFixes/config.yml
@@ -298,7 +298,7 @@ combat:
     max-bow-squared-velocity: 15
   crystal-aura:
     regular-delay:
-      enable: false
+      enable: true
       delay-in-ticks: 4
       # Use this if youre on 1.12, otherwise the delay will not work.
       prevent-placing-crystals: false

--- a/servers/2-main/plugins/AnarchyExploitFixes/config.yml
+++ b/servers/2-main/plugins/AnarchyExploitFixes/config.yml
@@ -299,7 +299,7 @@ combat:
   crystal-aura:
     regular-delay:
       enable: true
-      delay-in-ticks: 4
+      delay-in-ticks: 3
       # Use this if youre on 1.12, otherwise the delay will not work.
       prevent-placing-crystals: false
     piston-aura-delay:


### PR DESCRIPTION
mudei a opção pra colocar um delay em 4 ticks pro crystal conseguir ser recolocado, esse delay não é muito grande e evita um exploit de spammar crystal muito rapidamente, que virou um problema após a atualizacao 1.19
mrow