### PR TITLE
Update Config AEF

### DIFF
--- a/servers/2-main/plugins/AnarchyExploitFixes/config.yml
+++ b/servers/2-main/plugins/AnarchyExploitFixes/config.yml
@@ -283,7 +283,7 @@ dupe-preventions:
 ############
 combat:
   prevent-burrow:
-    enable: true
+    enable: false
     # 1.0 = Half a heart of damage every time you move.
     damage-when-moving: 1.0
     teleport-above-block: true
@@ -298,7 +298,7 @@ combat:
     max-bow-squared-velocity: 15
   crystal-aura:
     regular-delay:
-      enable: false
+      enable: true
       delay-in-ticks: 4
       # Use this if youre on 1.12, otherwise the delay will not work.
       prevent-placing-crystals: false
@@ -837,7 +837,7 @@ elytra:
       speed-old-chunks: 1.81
       speed-new-chunks: 1.81
       enable-bursting: true
-      burst-speed-old-chunks: 5.0
+      burst-speed-old-chunks: 3.0
       burst-speed-old-chunk-TPS: 18.0
       burst-speed-new-chunks: 3.12
       burst-speed-new-chunk-TPS: 19.0


### PR DESCRIPTION
Adições:
- A velocidade do CA foi reduzida, fazendo com que Crystal Spam não seja mais viável
- Patch de burrow foi desligado. Já foi encontrado bypass para o patch do AEF, e dá para se criar um elevador, teleportando o player um bloco acima
- Update no elytrafly, ultimamente, o grande load de novas chunks tem causado queda drástica do TPS, e parte disso tem a ver com a speed permitida no elytra fly (máxima anteriormente)
- Obrigado meus pais pela educacao