### PR TITLE
[ Prevenção ] md_5 "exploit"

### DIFF
--- a/servers/0-proxy/config.yml
+++ b/servers/0-proxy/config.yml
@@ -21,11 +21,6 @@ permissions:
   default:
   - bungeecord.command.server
   - bungeecord.command.list
-  admin:
-  - bungeecord.command.alert
-  - bungeecord.command.end
-  - bungeecord.command.ip
-  - bungeecord.command.reload
 log_pings: true
 connection_throttle_limit: 3
 server_connect_timeout: 5000
@@ -34,8 +29,7 @@ player_limit: -1
 prevent_proxy_connections: false
 ip_forward: true
 groups:
-  md_5:
-  - admin
+  md_5: []
 remote_ping_timeout: 5000
 connection_throttle: 4000
 log_commands: false


### PR DESCRIPTION
Caso um jogador entra com a conta md_5, ele tem permissão para:
- Reiniciar o servidor
- Recarregar os plugins
- Emitir um alerta nos servidores 

Esse exploit foi testado no ssn e até então não funcionou, porém, para evitar eventuais problemas esse pull request remove essas permissões para esse nickname.